### PR TITLE
fix: add loaded metadata event for video duration

### DIFF
--- a/src/cloudinary-analytics.js
+++ b/src/cloudinary-analytics.js
@@ -4,7 +4,6 @@ import { getVideoViewId } from './utils/video-view-id';
 import { getUserId } from './utils/user-id';
 import { setupManualDataCollector } from './data-collectors/manual-data-collector';
 import { setupAutomaticDataCollector } from './data-collectors/automatic-data-collector';
-import { getVideoMetadata } from './utils/video-metadata';
 import { sendBeaconRequest } from './utils/send-beacon-request';
 import { getVideoSource } from './utils/video-source';
 
@@ -37,7 +36,6 @@ export const connectCloudinaryAnalytics = (videoElement) => {
       videoUrl: getVideoSource(videoElement),
       userId: getUserId(),
       viewId,
-      videoMetadata: getVideoMetadata(videoElement),
     }, videoWatchSessionEventCollector.flushEvents, sendData);
 
     videoTrackingSession = {
@@ -67,7 +65,6 @@ export const connectCloudinaryAnalytics = (videoElement) => {
         videoUrl: getVideoSource(videoElement),
         userId: getUserId(),
         viewId,
-        videoMetadata: getVideoMetadata(videoElement),
       }, videoWatchSessionEventCollector.flushEvents, sendData);
 
       videoTrackingSession = {

--- a/src/data-collectors/automatic-data-collector.js
+++ b/src/data-collectors/automatic-data-collector.js
@@ -1,51 +1,10 @@
-import { VIDEO_EVENT } from '../events.consts';
+import { aggregateEvents, getPlayedTimeSeconds, prepareEvents } from '../utils/events-parser';
 
-// prepare events list for aggregation, for example
-// if video is being played and user wants to leave the page - add "pause" event to correctly calculate played time
-const prepareEvents = (collectedEvents) => {
-  const events = [...collectedEvents];
-  const lastPlayItemIndex = events.findLastIndex(({ eventName }) => eventName === VIDEO_EVENT.PLAY);
-  const lastPauseItemIndex = events.findLastIndex(({ eventName }) => eventName === VIDEO_EVENT.PAUSE);
-
-  if (lastPlayItemIndex > lastPauseItemIndex) {
-    events.push({
-      eventName: VIDEO_EVENT.PAUSE,
-      eventDetails: {
-        time: Date.now(),
-      },
-    });
-  }
-
-  return events;
-};
-
-const aggregateEvents = (eventsList) => {
-  return eventsList.reduce((acc, event) => {
-    const lastItem = acc.watchedFrames[acc.watchedFrames.length - 1];
-    const eventTime = event.eventDetails.time;
-
-    if (event.eventName === VIDEO_EVENT.PLAY) {
-      acc.watchedFrames.push([eventTime]);
-    } else if (lastItem && lastItem.length === 1 && event.eventName === VIDEO_EVENT.PAUSE) {
-      lastItem.push(eventTime);
-    }
-
-    return acc;
-  }, {
-    watchedFrames: []
-  });
-};
-
-const getPlayedTimeSeconds = (watchedFrames) => {
-  return Math.round(watchedFrames.reduce((acc, [playTime, pauseTime]) => {
-    return acc + ((pauseTime - playTime) / 1000);
-  }, 0));
-};
 export const setupAutomaticDataCollector = (data, flushEvents, sendData) => {
   const sendVideoData = () => {
     const collectedEvents = flushEvents();
     const events = prepareEvents(collectedEvents);
-    const { watchedFrames } = aggregateEvents(events);
+    const { watchedFrames, videoMetadata } = aggregateEvents(events);
     const playedTimeSeconds = getPlayedTimeSeconds(watchedFrames);
 
     sendData({
@@ -53,7 +12,7 @@ export const setupAutomaticDataCollector = (data, flushEvents, sendData) => {
       userId: data.userId,
       viewId: data.viewId,
       playedTimeSeconds,
-      videoDuration: data.videoMetadata.videoDuration,
+      videoDuration: videoMetadata.videoDuration,
     });
   };
 

--- a/src/data-collectors/manual-data-collector.js
+++ b/src/data-collectors/manual-data-collector.js
@@ -1,51 +1,10 @@
-import { VIDEO_EVENT } from '../events.consts';
+import { aggregateEvents, getPlayedTimeSeconds, prepareEvents } from '../utils/events-parser';
 
-// prepare events list for aggregation, for example
-// if video is being played and user wants to leave the page - add "pause" event to correctly calculate played time
-const prepareEvents = (collectedEvents) => {
-  const events = [...collectedEvents];
-  const lastPlayItemIndex = events.findLastIndex(({ eventName }) => eventName === VIDEO_EVENT.PLAY);
-  const lastPauseItemIndex = events.findLastIndex(({ eventName }) => eventName === VIDEO_EVENT.PAUSE);
-
-  if (lastPlayItemIndex > lastPauseItemIndex) {
-    events.push({
-      eventName: VIDEO_EVENT.PAUSE,
-      eventDetails: {
-        time: Date.now(),
-      },
-    });
-  }
-
-  return events;
-};
-
-const aggregateEvents = (eventsList) => {
-  return eventsList.reduce((acc, event) => {
-    const lastItem = acc.watchedFrames[acc.watchedFrames.length - 1];
-    const eventTime = event.eventDetails.time;
-
-    if (event.eventName === VIDEO_EVENT.PLAY) {
-      acc.watchedFrames.push([eventTime]);
-    } else if (lastItem && lastItem.length === 1 && event.eventName === VIDEO_EVENT.PAUSE) {
-      lastItem.push(eventTime);
-    }
-
-    return acc;
-  }, {
-    watchedFrames: []
-  });
-};
-
-const getPlayedTimeSeconds = (watchedFrames) => {
-  return Math.round(watchedFrames.reduce((acc, [playTime, pauseTime]) => {
-    return acc + ((pauseTime - playTime) / 1000);
-  }, 0));
-};
 export const setupManualDataCollector = (data, flushEvents, sendData) => {
   const sendVideoData = () => {
     const collectedEvents = flushEvents();
     const events = prepareEvents(collectedEvents);
-    const { watchedFrames } = aggregateEvents(events);
+    const { watchedFrames, videoMetadata } = aggregateEvents(events);
     const playedTimeSeconds = getPlayedTimeSeconds(watchedFrames);
 
     sendData({
@@ -55,7 +14,7 @@ export const setupManualDataCollector = (data, flushEvents, sendData) => {
       videoPublicId: data.publicId,
       viewId: data.viewId,
       playedTimeSeconds,
-      videoDuration: data.videoMetadata.videoDuration,
+      videoDuration: videoMetadata.videoDuration,
     });
   };
 

--- a/src/events-collector.js
+++ b/src/events-collector.js
@@ -1,5 +1,6 @@
 import { registerPlayEvent } from './events/play-event';
 import { registerPauseEvent } from './events/pause-event';
+import { registerMetadataEvent } from './events/metadata-event';
 
 export const initEventsCollector = (videoElement) => {
   const collectedEvents = {};
@@ -21,6 +22,7 @@ export const initEventsCollector = (videoElement) => {
     const registeredEvents = [
       registerPlayEvent(videoElement, reportEvent),
       registerPauseEvent(videoElement, reportEvent),
+      registerMetadataEvent(videoElement, reportEvent),
     ];
     const flushEvents = () => {
       const events = videoWatchSessionRawEvents.splice(0, videoWatchSessionRawEvents.length);

--- a/src/events.consts.js
+++ b/src/events.consts.js
@@ -1,4 +1,5 @@
 export const VIDEO_EVENT = {
   PLAY: 'play',
-  PAUSE: 'pause'
+  PAUSE: 'pause',
+  LOADED_METADATA: 'loadedmetadata',
 };

--- a/src/events/metadata-event.js
+++ b/src/events/metadata-event.js
@@ -1,0 +1,16 @@
+import { VIDEO_EVENT } from '../events.consts';
+import { getVideoMetadata } from '../utils/video-metadata';
+
+export const registerMetadataEvent = (videoElement, reportEvent) => {
+  const eventListener = () => {
+    const videoMetadata = getVideoMetadata(videoElement);
+    reportEvent(VIDEO_EVENT.LOADED_METADATA, {
+      videoDuration: videoMetadata.videoDuration,
+    });
+  };
+  videoElement.addEventListener('loadedmetadata', eventListener);
+
+  return () => {
+    videoElement.removeEventListener('loadedmetadata', eventListener);
+  };
+};

--- a/src/utils/events-parser.js
+++ b/src/utils/events-parser.js
@@ -1,0 +1,48 @@
+import { VIDEO_EVENT } from '../events.consts';
+
+// prepare events list for aggregation, for example
+// if video is being played and user wants to leave the page - add "pause" event to correctly calculate played time
+export const prepareEvents = (collectedEvents) => {
+  const events = [...collectedEvents];
+  const lastPlayItemIndex = events.findLastIndex(({ eventName }) => eventName === VIDEO_EVENT.PLAY);
+  const lastPauseItemIndex = events.findLastIndex(({ eventName }) => eventName === VIDEO_EVENT.PAUSE);
+
+  if (lastPlayItemIndex > lastPauseItemIndex) {
+    events.push({
+      eventName: VIDEO_EVENT.PAUSE,
+      eventDetails: {
+        time: Date.now(),
+      },
+    });
+  }
+
+  return events;
+};
+
+export const aggregateEvents = (eventsList) => {
+  return eventsList.reduce((acc, event) => {
+    const lastItem = acc.watchedFrames[acc.watchedFrames.length - 1];
+    const eventTime = event.eventDetails.time;
+
+    if (event.eventName === VIDEO_EVENT.LOADED_METADATA) {
+      acc.videoMetadata.videoDuration = event.eventDetails.videoDuration;
+    } else if (event.eventName === VIDEO_EVENT.PLAY) {
+      acc.watchedFrames.push([eventTime]);
+    } else if (lastItem && lastItem.length === 1 && event.eventName === VIDEO_EVENT.PAUSE) {
+      lastItem.push(eventTime);
+    }
+
+    return acc;
+  }, {
+    watchedFrames: [],
+    videoMetadata: {
+      videoDuration: null,
+    },
+  });
+};
+
+export const getPlayedTimeSeconds = (watchedFrames) => {
+  return Math.round(watchedFrames.reduce((acc, [playTime, pauseTime]) => {
+    return acc + ((pauseTime - playTime) / 1000);
+  }, 0));
+};


### PR DESCRIPTION
To make sure we have video duration available I added simple event - `loadedmetadata` which is added to events list and before sending analytics we read it there directly from video element.