### PR TITLE
fix: fire beforeunload event only once

### DIFF
--- a/src/default-data-collector.js
+++ b/src/default-data-collector.js
@@ -10,7 +10,9 @@ export const setupDefaultDataCollector = (data, flushEvents, sendData) => {
     });
   };
 
-  window.addEventListener('beforeunload', sendVideoData);
+  window.addEventListener('beforeunload', sendVideoData, {
+    once: true,
+  });
 
   return () => {
     window.removeEventListener('beforeunload', sendVideoData);


### PR DESCRIPTION
Fire `beforeunload` event only once