### PR TITLE
feat: add custom events to support custom players

### DIFF
--- a/src/events-collector.js
+++ b/src/events-collector.js
@@ -1,10 +1,10 @@
-import { registerPlayEvent } from './events/play-event';
-import { registerPauseEvent } from './events/pause-event';
-import { registerMetadataEvent } from './events/metadata-event';
+import { registerNativePlayEvent, registerCustomPlayEvent } from './events/play-event';
+import { registerNativePauseEvent, registerCustomPauseEvent } from './events/pause-event';
+import { registerNativeMetadataEvent, registerCustomMetadataEvent } from './events/metadata-event';
 import { createEvent } from './utils/create-event';
 import { tryInitEvents } from './utils/video-metadata';
 
-export const initEventsCollector = (videoElement) => {
+export const initEventsCollector = (videoElement, shouldUseCustomEvents) => {
   const collectedEvents = {};
   const rawEvents = {};
 
@@ -16,12 +16,16 @@ export const initEventsCollector = (videoElement) => {
     const videoViewRawEvents = rawEvents[viewId];
 
     const reportEvent = (eventName, eventDetails) => videoViewRawEvents.push(createEvent(eventName, eventDetails));
-    const registeredEvents = [
-      registerPlayEvent(videoElement, reportEvent),
-      registerPauseEvent(videoElement, reportEvent),
-      registerMetadataEvent(videoElement, reportEvent),
+    const registeredEvents = shouldUseCustomEvents ? [
+      registerCustomPlayEvent(videoElement, reportEvent),
+      registerCustomPauseEvent(videoElement, reportEvent),
+      registerCustomMetadataEvent(videoElement, reportEvent),
+    ] : [
+      registerNativePlayEvent(videoElement, reportEvent),
+      registerNativePauseEvent(videoElement, reportEvent),
+      registerNativeMetadataEvent(videoElement, reportEvent),
     ];
-    tryInitEvents(videoElement);
+    tryInitEvents(videoElement, shouldUseCustomEvents);
     const flushEvents = () => {
       const events = videoViewRawEvents.splice(0, videoViewRawEvents.length);
       videoViewCollectedEvents.splice(videoViewCollectedEvents.length, 0, ...events);

--- a/src/events.consts.js
+++ b/src/events.consts.js
@@ -4,6 +4,8 @@ export const VIDEO_EVENT = {
   LOADED_METADATA: 'loadMetadata',
 };
 
+export const VIDEO_CUSTOM_EVENT_PREFIX = 'cld-custom-';
+
 export const VIEW_EVENT = {
   START: 'viewStart',
   END: 'viewEnd',

--- a/src/events/metadata-event.js
+++ b/src/events/metadata-event.js
@@ -1,7 +1,7 @@
-import { VIDEO_EVENT } from '../events.consts';
+import { VIDEO_CUSTOM_EVENT_PREFIX, VIDEO_EVENT } from '../events.consts';
 import { getVideoMetadata } from '../utils/video-metadata';
 
-export const registerMetadataEvent = (videoElement, reportEvent) => {
+export const registerNativeMetadataEvent = (videoElement, reportEvent) => {
   const eventListener = () => {
     const videoMetadata = getVideoMetadata(videoElement);
     reportEvent(VIDEO_EVENT.LOADED_METADATA, {
@@ -14,5 +14,28 @@ export const registerMetadataEvent = (videoElement, reportEvent) => {
   return () => {
     videoElement.removeEventListener('loadedmetadata', eventListener);
     videoElement.removeEventListener('loadedmetadata_after_init', eventListener);
+  };
+};
+
+export const registerCustomMetadataEvent = (videoElement, reportEvent) => {
+  const loadedmetadataEventListener = (event) => {
+    const videoMetadata = getVideoMetadata(videoElement);
+    const videoDuration = event.detail.videoDuration || videoMetadata.videoDuration;
+    reportEvent(VIDEO_EVENT.LOADED_METADATA, {
+      videoDuration,
+    });
+  };
+  videoElement.addEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}loadedmetadata`, loadedmetadataEventListener);
+
+  const loadedmetadataAfterInitEventListener = (event) => {
+    reportEvent(VIDEO_EVENT.LOADED_METADATA, {
+      videoDuration: typeof event.detail.videoDuration !== 'number' && event.detail.videoDuration > 0 ? null : event.detail.videoDuration,
+    });
+  };
+  videoElement.addEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}loadedmetadata_after_init`, loadedmetadataAfterInitEventListener);
+
+  return () => {
+    videoElement.removeEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}loadedmetadata`, loadedmetadataEventListener);
+    videoElement.removeEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}loadedmetadata_after_init`, loadedmetadataAfterInitEventListener);
   };
 };

--- a/src/events/pause-event.js
+++ b/src/events/pause-event.js
@@ -1,6 +1,6 @@
-import { VIDEO_EVENT } from '../events.consts';
+import { VIDEO_CUSTOM_EVENT_PREFIX, VIDEO_EVENT } from '../events.consts';
 
-export const registerPauseEvent = (videoElement, reportEvent) => {
+export const registerNativePauseEvent = (videoElement, reportEvent) => {
   const pauseEventListener = () => {
     reportEvent(VIDEO_EVENT.PAUSE, {});
   };
@@ -11,7 +11,23 @@ export const registerPauseEvent = (videoElement, reportEvent) => {
   videoElement.addEventListener('emptied', emptiedEventListener);
 
   return () => {
-    videoElement.removeEventListener('play', pauseEventListener);
+    videoElement.removeEventListener('pause', pauseEventListener);
     videoElement.removeEventListener('emptied', emptiedEventListener);
+  };
+};
+
+export const registerCustomPauseEvent = (videoElement, reportEvent) => {
+  const pauseEventListener = () => {
+    reportEvent(VIDEO_EVENT.PAUSE, {});
+  };
+  videoElement.addEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}pause`, pauseEventListener);
+  const emptiedEventListener = () => {
+    reportEvent(VIDEO_EVENT.PAUSE, {});
+  };
+  videoElement.addEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}emptied`, emptiedEventListener);
+
+  return () => {
+    videoElement.removeEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}pause`, pauseEventListener);
+    videoElement.removeEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}emptied`, emptiedEventListener);
   };
 };

--- a/src/events/play-event.js
+++ b/src/events/play-event.js
@@ -1,6 +1,6 @@
-import { VIDEO_EVENT } from '../events.consts';
+import { VIDEO_EVENT, VIDEO_CUSTOM_EVENT_PREFIX } from '../events.consts';
 
-export const registerPlayEvent = (videoElement, reportEvent) => {
+export const registerNativePlayEvent = (videoElement, reportEvent) => {
   const eventListener = () => {
     reportEvent(VIDEO_EVENT.PLAY, {});
   };
@@ -8,5 +8,16 @@ export const registerPlayEvent = (videoElement, reportEvent) => {
 
   return () => {
     videoElement.removeEventListener('play', eventListener);
+  };
+};
+
+export const registerCustomPlayEvent = (videoElement, reportEvent) => {
+  const eventListener = () => {
+    reportEvent(VIDEO_EVENT.PLAY, {});
+  };
+  videoElement.addEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}play`, eventListener);
+
+  return () => {
+    videoElement.removeEventListener(`${VIDEO_CUSTOM_EVENT_PREFIX}play`, eventListener);
   };
 };

--- a/src/utils/video-metadata.js
+++ b/src/utils/video-metadata.js
@@ -1,3 +1,5 @@
+import { VIDEO_CUSTOM_EVENT_PREFIX } from '../events.consts';
+
 export const getVideoMetadata = (videoElement) => {
   const videoElementDuration = videoElement.duration;
   const videoDuration = Number.isNaN(videoElementDuration) ? null : videoElementDuration;
@@ -6,9 +8,10 @@ export const getVideoMetadata = (videoElement) => {
   };
 };
 
-export const tryInitEvents = (videoElement) => {
+export const tryInitEvents = (videoElement, shouldUseCustomEvents) => {
   if (videoElement.readyState > 0) {
-    const event = new CustomEvent('loadedmetadata_after_init');
+    const eventName = shouldUseCustomEvents ? `${VIDEO_CUSTOM_EVENT_PREFIX}loadedmetadata_after_init` : 'loadedmetadata_after_init';
+    const event = new CustomEvent(eventName);
     videoElement.dispatchEvent(event);
   }
 };


### PR DESCRIPTION
Unfortunately video.js that is used in our CLD VP intercept all video events on HTML tag which causes problems only on iOS mobile browsers.

I added possibility to listen for custom events instead of native ones. It's also good that now we can easily integrate with any lib that does the same thing as videojs - intercept native events.