### PR TITLE
feat: custom data values

### DIFF
--- a/dev/main.js
+++ b/dev/main.js
@@ -79,10 +79,11 @@ window.addEventListener('load', () => {
   connectAutoVideoPanel();
   autoCloudinaryAnalytics.startAutoTracking({
     providedData: {
-      example: 1,
-      thisPackageIsAwesome: true,
-      test: 'test',
-      thisShouldBeSkipped: {
+      customData1: 1, // skipped
+      customData2: 'value',
+      test: 'test', // skipped
+      customData5: 'another-value',
+      thisShouldBeSkipped: { // skipped
         value: 1,
       },
     },

--- a/src/utils/customer-data.js
+++ b/src/utils/customer-data.js
@@ -1,7 +1,7 @@
 const CUSTOMER_DATA_CHARS_LIMIT = 1000;
 
-const filterProvidedData = (data) => {
-  return Array(5).reduce((obj, cv, currentIndex) => {
+const filterOutNonStrings = (data) => {
+  return Array.from({ length: 5 }).reduce((obj, cv, currentIndex) => {
     const key = `customData${currentIndex + 1}`;
 
     if (typeof data[key] === 'string') {
@@ -12,18 +12,16 @@ const filterProvidedData = (data) => {
   }, {})
 };
 
-export const parseProvidedData = (data) => {
+export const parseProvidedData = (providedData) => {
+  const data = typeof providedData === 'function' ? providedData() : providedData;
+
   if (typeof data === 'object' && data !== null && !Array.isArray(data)) {
-    const filteredData = filterProvidedData(data);
-    return Object.keys(filteredData).length > 0 ? filteredData : null;
-  } else if (typeof data === 'function') {
-    const dataFnResult = data();
-    const filteredData = filterProvidedData(dataFnResult);
+    const filteredData = filterOutNonStrings(data);
     return Object.keys(filteredData).length > 0 ? filteredData : null;
   }
 
   return null;
-};
+}
 
 export const isProvidedDataValid = (providedData) => {
   if (providedData === null) {

--- a/src/utils/customer-data.js
+++ b/src/utils/customer-data.js
@@ -1,17 +1,25 @@
-const ALLOWED_DATA_TYPES = ['string', 'number', 'boolean'];
 const CUSTOMER_DATA_CHARS_LIMIT = 1000;
+
+const filterProvidedData = (data) => {
+  return Array(5).reduce((obj, cv, currentIndex) => {
+    const key = `customData${currentIndex + 1}`;
+
+    if (typeof data[key] === 'string') {
+      obj[key] = data[key];
+    }
+
+    return obj;
+  }, {})
+};
 
 export const parseProvidedData = (data) => {
   if (typeof data === 'object' && data !== null && !Array.isArray(data)) {
-    const parsedData = Object.keys(data).reduce((collection, dataKey) => {
-      if (ALLOWED_DATA_TYPES.includes(typeof data[dataKey]) || data[dataKey] === null) {
-        collection[dataKey] = data[dataKey];
-      }
-
-      return collection;
-    }, {});
-
-    return Object.keys(parsedData).length > 0 ? parsedData : null;
+    const filteredData = filterProvidedData(data);
+    return Object.keys(filteredData).length > 0 ? filteredData : null;
+  } else if (typeof data === 'function') {
+    const dataFnResult = data();
+    const filteredData = filterProvidedData(dataFnResult);
+    return Object.keys(filteredData).length > 0 ? filteredData : null;
   }
 
   return null;


### PR DESCRIPTION
From now on we expect provided data from user to keep schema supported by us.
Supported schema:
```
{
  customData1: string;
  customData2: string;
  customData3: string;
  customData4: string;
  customData5: string;
}
```

Every extra key or proper ones that are no string will be filtered out.
It can be also function which will be called at the beginning of view start event (when analytics tracking for new video has started).

Function for provided data is simple from start - if we notice need to add some more context of execution (like current public id etc) - it will be added at that time.